### PR TITLE
Missing Content references in WP7 and X360 projects

### DIFF
--- a/XNA/FFWD.Template/FFWD.Template.WP7.csproj
+++ b/XNA/FFWD.Template/FFWD.Template.WP7.csproj
@@ -69,9 +69,19 @@
       <Project>{2370CE44-C54A-4553-B0C1-5971DA50254A}</Project>
       <Name>PressPlay.FFWD.WP7</Name>
     </ProjectReference>
+    <ProjectReference Include="..\FFWD.Template.Content\FFWD.Template.Content.contentproj">
+      <Project>{E5DFEFA2-635A-416B-957E-0AB2BC297BCB}</Project>
+      <Name>FFWD.Template.Content %28Content%29</Name>
+      <XnaReferenceType>Content</XnaReferenceType>
+    </ProjectReference>
     <ProjectReference Include="..\FFWD.Template.Scripts\FFWD.Template.Scripts.WP7.csproj">
       <Project>{6062F254-F991-49B4-953B-D5867416C1E6}</Project>
       <Name>FFWD.Unity.Tests.Scripts.WP7</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FFWD.Template.XmlContent\FFWD.Template.XmlContent.contentproj">
+      <Project>{5E05D831-E8A3-4D6D-909B-8949D3BABA41}</Project>
+      <Name>FFWD.Template.XmlContent %28Content%29</Name>
+      <XnaReferenceType>Content</XnaReferenceType>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/XNA/FFWD.Template/FFWD.Template.X360.csproj
+++ b/XNA/FFWD.Template/FFWD.Template.X360.csproj
@@ -62,9 +62,19 @@
       <Project>{1034C53A-128D-4F83-BAC0-706151EAEC94}</Project>
       <Name>PressPlay.FFWD.X360</Name>
     </ProjectReference>
+    <ProjectReference Include="..\FFWD.Template.Content\FFWD.Template.Content.contentproj">
+      <Project>{E5DFEFA2-635A-416B-957E-0AB2BC297BCB}</Project>
+      <Name>FFWD.Template.Content %28Content%29</Name>
+      <XnaReferenceType>Content</XnaReferenceType>
+    </ProjectReference>
     <ProjectReference Include="..\FFWD.Template.Scripts\FFWD.Template.Scripts.X360.csproj">
       <Project>{1C8FE13D-BEAF-437C-908A-5AC780102B31}</Project>
       <Name>FFWD.Template.Scripts.X360</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FFWD.Template.XmlContent\FFWD.Template.XmlContent.contentproj">
+      <Project>{5E05D831-E8A3-4D6D-909B-8949D3BABA41}</Project>
+      <Name>FFWD.Template.XmlContent %28Content%29</Name>
+      <XnaReferenceType>Content</XnaReferenceType>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Added references to FFWD.Template.Content and FFWD.Template.XmlContent in both projects.
